### PR TITLE
add KeepOpen mode to White light

### DIFF
--- a/custom_components/icsee_ptz/select.py
+++ b/custom_components/icsee_ptz/select.py
@@ -46,7 +46,7 @@ DAY_NIGHT_COLOR_MAPPING = {
 
 DAY_NIGHT_COLOR_MAPPING_INV = {v: k for k, v in DAY_NIGHT_COLOR_MAPPING.items()}
 
-WHITE_LIGHT_WORK_MODE_LIST = ['Intelligent', 'Auto', 'Close']
+WHITE_LIGHT_WORK_MODE_LIST = ['Intelligent', 'Auto', 'KeepOpen', 'Close']
 
 class DayNightColorSelect(ICSeeEntity, SelectEntity):
     def __init__(self, hass: HomeAssistant, entry: ConfigEntry, channel: int = 0):


### PR DESCRIPTION
Add the ability to keep the white light on to allow the camera to operate in the same manner as a regular light bulb.

NB. This documentation suggests further modes available, but Atmosphere/Glint didn't do anything with my particular camera. https://docs.jftech.com/docs?menusId=2531aba7e2d84e13ad8ce977007922f3&siderId=0b5f202818ae472da8d0a9dccf72e632&lang=zh